### PR TITLE
Add properties to hubspot company api call

### DIFF
--- a/etl/app.py
+++ b/etl/app.py
@@ -24,7 +24,7 @@ def upload_deals_to_bigquery():
 
 @app.task
 def upload_companies_to_bigquery():
-    company_data = hubspot.HubspotAPI.get_instance("/crm/v3/objects/companies").get_data()
+    company_data = hubspot.HubspotAPI.get_instance("/crm/v3/objects/companies?properties=createdate,name,hubspot_owner_id,annualrevenue,country").get_data()
     company_data = hubspot.flatten_companies(company_data)
     bigquery.upload_json_to_table(company_data, "hubspot.company")
 

--- a/etl/connectors/hubspot.py
+++ b/etl/connectors/hubspot.py
@@ -53,7 +53,10 @@ def flatten_companies(data):
         flat_dict = {
             "id": result["id"],
             "createdate": result["properties"]["createdate"],
-            "name": result["properties"]["name"]
+            "name": result["properties"]["name"],
+            "annualrevenue": result["properties"]["annualrevenue"],
+            "hubspot_owner_id": result["properties"]["hubspot_owner_id"],
+            "country": result["properties"]["country"]
         }
         flattened_data.append(flat_dict)
     return flattened_data


### PR DESCRIPTION
- Add annualrevenue, country, and hubspot_owner_id properties top hubspot company api call in `app.py`
- Update `flatten_companies` function in `connectors/hubspot.py` to accommodate new properties in company api response